### PR TITLE
Revert "adjust sqlcheck"

### DIFF
--- a/bin/utils
+++ b/bin/utils
@@ -99,7 +99,7 @@ python3_check() {
 # Check if Python version needs to install SQLite3
 python_sqlite3_check() {
   VERSION="$1"
-  MIN_PYTHON_3="python-3.5.6"
+  MIN_PYTHON_3="python-3.6.6"
   MIN_PYTHON_2="python-2.7.15"
 
   ( python2_check "$VERSION" && version_gte "$VERSION" "$MIN_PYTHON_2" ) \


### PR DESCRIPTION
This reverts commit 2f430abf075af9aaf9ceaf61b96f9b42597185c1.

This change was intended to add the sqlite3 download for 3.5.6, but it also adds it for 3.6.x. Since we don't support the sqlite3 download yet, this breaks 3.6.x.

Given that we don't currently support 3.5.6 anyway, the best thing to do is to revert this commit.

@gzork Please review.