### PR TITLE
3.6.5 python in airgap mode

### DIFF
--- a/bin/default_pythons
+++ b/bin/default_pythons
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 
 DEFAULT_PYTHON_VERSION="python-3.6.8"
+
+if [[ $PLOTLY_IS_AIRGAPPED -eq 1 ]]; then
+    DEFAULT_PYTHON_VERSION="python-3.6.5"
+fi
+
 LATEST_36="python-3.6.8"
 LATEST_37="python-3.7.3"
 LATEST_35="python-3.5.7"

--- a/bin/default_pythons
+++ b/bin/default_pythons
@@ -2,7 +2,7 @@
 
 DEFAULT_PYTHON_VERSION="python-3.6.8"
 
-if [[ $PLOTLY_IS_AIRGAPPED -eq 1 ]]; then
+if [[ "$PLOTLY_IS_AIRGAPPED" == "1" ]]; then
     DEFAULT_PYTHON_VERSION="python-3.6.5"
 fi
 


### PR DESCRIPTION
- buildpack fix for https://github.com/plotly/streambed/issues/13569
- sets default Python version to working v3.6.5 when in airgap mode

@josegonzalez please review! 