### PR TITLE
fix airgap default

### DIFF
--- a/bin/default_pythons
+++ b/bin/default_pythons
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
 
 DEFAULT_PYTHON_VERSION="python-3.6.8"
-LATEST_36="python-3.6.8"
+
+if [[ "$PLOTLY_IS_AIRGAPPED" == "1" ]]; then
+    DEFAULT_PYTHON_VERSION="python-3.6.5"
+fi
+
 LATEST_37="python-3.7.3"
+LATEST_36="python-3.6.8"
 LATEST_35="python-3.5.7"
 LATEST_34="python-3.4.10"
 LATEST_27="python-2.7.16"


### PR DESCRIPTION
FYI @plotly/devops 

Already reviewed in: https://github.com/plotly/heroku-buildpack-python/pull/8

Once this is merged, I will tag as 3.3.0b6 and update the herokuish build. 