### PR TITLE
Allow custom main pypi index

### DIFF
--- a/bin/steps/pip-install
+++ b/bin/steps/pip-install
@@ -18,6 +18,13 @@ if [ ! "$SKIP_PIP_INSTALL" ]; then
         export PIP_EXTRA_INDEX_URL
         mcount "buildvar.PIP_EXTRA_INDEX_URL"
     fi
+    #
+    # PIP_INDEX_URL allows for custom pypi URL to be used.
+    if [[ -r "$ENV_DIR/PIP_INDEX_URL" ]]; then
+        PIP_INDEX_URL="$(cat "$ENV_DIR/PIP_INDEX_URL")"
+        export PIP_INDEX_URL
+        mcount "buildvar.PIP_INDEX_URL"
+    fi
 
     set +e
 


### PR DESCRIPTION
Part of plotly/streambed#13508

This PR checks if `PIP_INDEX_URL` is set and uses it in the app build instead of the public pip index.

The details on how this was tested are in [this PR](https://github.com/plotly/dash-deployment-server/pull/570).