### PR TITLE
Fallback to heroku vendor if dds doesn't provide the requested runtime.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -41,9 +41,11 @@ export BUILD_DIR CACHE_DIR ENV_DIR
 # environment variable mechanism (the ENV_DIR).
 VENDOR_URL="https://lang-python.s3.amazonaws.com/$STACK"
 if [[ -n ${BUILDPACK_VENDOR_URL:-} ]]; then
+    FALLBACK_VENDOR_URL="$VENDOR_URL"
     VENDOR_URL="$BUILDPACK_VENDOR_URL"
 fi
 export VENDOR_URL
+export FALLBACK_VENDOR_URL
 
 # Default Python Versions
 # shellcheck source=bin/default_pythons

--- a/bin/steps/python
+++ b/bin/steps/python
@@ -13,8 +13,18 @@ SUPPORT_LINK="https://dash.plot.ly/dash-deployment-server/troubleshooting"
 
 TMP_CURL_OUTPUT=$(mktemp)
 
+check_runtime () {
+  if ! curl --output /dev/null --verbose --head --fail "$VENDORED_PYTHON" 2>"$TMP_CURL_OUTPUT" \
+      && [[ "$PLOTLY_IS_AIRGAPPED" == "0" ]]; then
+    puts-warn "Falling back to heroku vendor."
+    VENDORED_PYTHON="${FALLBACK_VENDOR_URL}/runtimes/$PYTHON_VERSION.tar.gz"
+    curl --output /dev/null --verbose --head --fail "$VENDORED_PYTHON" 2>"$TMP_CURL_OUTPUT"
+  fi
+  return $?
+}
+
 # check if runtime exists
-if curl --output /dev/null --verbose --head --fail "$VENDORED_PYTHON" 2>"$TMP_CURL_OUTPUT"; then
+if check_runtime; then
   if [[ "$PYTHON_VERSION" == $PY37* ]]; then
     # do things to alert the user of security release available
     if [ "$PYTHON_VERSION" != "$LATEST_37" ]; then


### PR DESCRIPTION
Part of https://github.com/plotly/streambed/issues/13625

### How I tested

- [x] Starting with DOPSA, add a `.buildpacks` file pointing to `https://github.com/plotly/heroku-buildpack-python#use-both-vendors`
  - [x] Deploy dopsa without `runtime.txt` and ensure that the deploy works
  - [x] Deploy dopsa with a `runtime.txt` file with a version of python that we do supply on `dds-vendor` and ensure that the deploy works
  - [x] Deploy dopsa with a `runtime.txt` that we do no supply but heroku does and ensure that the deploy works
  - [x] Deploy dopsa to an airgapped instance without a `runtime.txt` file and ensure that the deploy works
  - [x] Deploy dopsa to an airgapped instance with a `runtime.txt` file with a version of python that we do supply on `dds-vendor` and ensure that the deploy works
  - [x] Deploy dopsa to an airgapped instance with a `runtime.txt` that we do no supply but heroku does and ensure that the deploy fails
 
### How someone else can test

The `.buildpacks` step won't be necessary once we release a new `herokuish` image. All other steps apply.
