### PR TITLE
Use 3.6.10 as default python for airgapped

### DIFF
--- a/bin/default_pythons
+++ b/bin/default_pythons
@@ -7,10 +7,6 @@
 
 DEFAULT_PYTHON_VERSION="python-3.6.10"
 
-if [[ "$PLOTLY_IS_AIRGAPPED" == "1" ]]; then
-    DEFAULT_PYTHON_VERSION="python-3.6.12"
-fi
-
 LATEST_39="python-3.9.0"
 LATEST_38="python-3.8.6"
 LATEST_37="python-3.7.9"


### PR DESCRIPTION
Fixes https://github.com/plotly/streambed/issues/15471

**Test Plan:**

  - [x] Test that app deploys succesfully without `runtime.txt`