### PR TITLE
Use newer pip for 312

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -47,6 +47,7 @@ S3_BASE_URL="${BUILDPACK_S3_BASE_URL:-"https://heroku-buildpack-python.s3.amazon
 source "$BIN_DIR/default_pythons"
 
 # Supported Python Branches
+PY312="python-3.12"
 PY311="python-3.11"
 PY310="python-3.10"
 PY39="python-3.9"

--- a/bin/steps/python
+++ b/bin/steps/python
@@ -145,7 +145,12 @@ fi
 #  - we would still have to manage several versions of get-pip.py, to support older Pythons.
 # Instead, we use the pip wheel to install itself, using the method described here:
 # https://github.com/pypa/pip/issues/2351#issuecomment-69994524
-PIP_WHEEL_FILENAME="pip-${PIP_VERSION}-py2.py3-none-any.whl"
+if [[ "${PIP_VERSION}" == "20.2.4"  ]]; then
+  PIP_WHEEL_FILENAME="pip-${PIP_VERSION}-py2.py3-none-any.whl"
+else
+  PIP_WHEEL_FILENAME="pip-${PIP_VERSION}-py3-none-any.whl"
+fi
+
 PIP_WHEEL_URL="${S3_BASE_URL}/simple/pip/${PIP_WHEEL_FILENAME}"
 PIP_WHEEL="${TMPDIR:-/tmp}/${PIP_WHEEL_FILENAME}"
 

--- a/bin/steps/python
+++ b/bin/steps/python
@@ -126,6 +126,10 @@ if [[ "${PYTHON_VERSION}" == ${PY34}* ]]; then
 elif [[ "${PYTHON_VERSION}" == ${PY27}* || "${PYTHON_VERSION}" == ${PYPY27}* ]]; then
   # Python 2.7 support was dropped in setuptools 45+.
   SETUPTOOLS_VERSION='44.1.1'
+
+elif [[ "${PYTHON_VERSION}" == ${PY312}* || "${PYTHON_VERSION}" == ${PY311}* || "${PYTHON_VERSION}" == ${PY310}* ]]; then
+  # Python 3.12 dropped support for older pip
+  PIP_VERSION='23.3.1'
 fi
 
 # We don't use get-pip.py, since:

--- a/bin/steps/python
+++ b/bin/steps/python
@@ -132,6 +132,12 @@ elif [[ "${PYTHON_VERSION}" == ${PY312}* || "${PYTHON_VERSION}" == ${PY311}* || 
   PIP_VERSION='23.3.1'
 fi
 
+if [ -f "pip-version.txt" ]
+then
+    PIP_VERSION=$(cat pip-version.txt)
+    puts-warn "Using Pip Version from pip-version.txt: $PIP_VERSION"
+fi
+
 # We don't use get-pip.py, since:
 #  - it uses `--force-reinstall`, which is unnecessary here and slows down repeat builds
 #  - it means downloading pip twice (once embedded in get-pip.py, and again during

--- a/bin/steps/python
+++ b/bin/steps/python
@@ -113,9 +113,7 @@ rm -f "$TMP_CURL_OUTPUT"
 set -e
 
 PIP_VERSION='23.3.1'
-# Must use setuptools <47.2.0 until we fix:
-# https://github.com/heroku/heroku-buildpack-python/issues/1006
-SETUPTOOLS_VERSION='47.1.1'
+SETUPTOOLS_VERSION='69.0.2'
 WHEEL_VERSION='0.34.2'
 
 if [[ "${PYTHON_VERSION}" == ${PY34}* ]]; then

--- a/bin/steps/python
+++ b/bin/steps/python
@@ -112,7 +112,7 @@ fi
 rm -f "$TMP_CURL_OUTPUT"
 set -e
 
-PIP_VERSION='20.2.4'
+PIP_VERSION='23.3.1'
 # Must use setuptools <47.2.0 until we fix:
 # https://github.com/heroku/heroku-buildpack-python/issues/1006
 SETUPTOOLS_VERSION='47.1.1'
@@ -126,11 +126,6 @@ if [[ "${PYTHON_VERSION}" == ${PY34}* ]]; then
 elif [[ "${PYTHON_VERSION}" == ${PY27}* || "${PYTHON_VERSION}" == ${PYPY27}* ]]; then
   # Python 2.7 support was dropped in setuptools 45+.
   SETUPTOOLS_VERSION='44.1.1'
-
-elif [[ "${PYTHON_VERSION}" == ${PY312}* || "${PYTHON_VERSION}" == ${PY311}* || "${PYTHON_VERSION}" == ${PY310}* ]]; then
-  # Python 3.12 dropped support for older pip
-  PIP_VERSION='23.3.1'
-fi
 
 if [ -f "pip-version.txt" ]
 then
@@ -184,7 +179,7 @@ else
 fi
 
 if [[ -n "$GET_PIP_PYPI_INDEX_URL" ]]; then
-  /app/.heroku/python/bin/python "${PIP_WHEEL}/pip" install --quiet --no-index "$GET_PIP_PYPI_INDEX_URL/pip/pip-${PIP_VERSION}-py2.py3-none-any.whl" "$GET_PIP_PYPI_INDEX_URL/setuptools/setuptools-${SETUPTOOLS_VERSION}-none-any.whl" "$GET_PIP_PYPI_INDEX_URL/wheel/wheel-${WHEEL_VERSION}-py2.py3-none-any.whl"
+  /app/.heroku/python/bin/python "${PIP_WHEEL}/pip" install --quiet --no-index "$PIP_WHEEL_URL" "$GET_PIP_PYPI_INDEX_URL/setuptools/setuptools-${SETUPTOOLS_VERSION}-none-any.whl" "$GET_PIP_PYPI_INDEX_URL/wheel/wheel-${WHEEL_VERSION}-py2.py3-none-any.whl"
 else
   /app/.heroku/python/bin/python "${PIP_WHEEL}/pip" install --quiet --disable-pip-version-check --no-cache "${PIP_TO_INSTALL}" "setuptools==${SETUPTOOLS_VERSION}" "wheel==${WHEEL_VERSION}"				   
 fi


### PR DESCRIPTION
This PR updates the buildpack to use newer pip as default and provides an option to continue using the older version of buildpack if needed.

The older version can be used by specifying version in a file called `pip-version.txt`